### PR TITLE
clarify options

### DIFF
--- a/website/crossbario/docs/Guest-Configuration.md
+++ b/website/crossbario/docs/Guest-Configuration.md
@@ -44,3 +44,5 @@ The `options` are:
 The argument `executable` provides the path to the executable that Crossbar.io uses when starting the worker. 
 
 Crossbar.io first parses this as an absolute path as well as a relative path (relative to the `workdir` in `options`). If no executable is found there, then it considers it an environment variable and attempts to use the path stored there.
+
+> **Note**: Python defaults to unbuffered stdout, so you probably want to [pass the -u option](https://docs.python.org/3/using/cmdline.html#cmdoption-u) when configuring Python guest workers.

--- a/website/crossbario/docs/Guest-Configuration.md
+++ b/website/crossbario/docs/Guest-Configuration.md
@@ -35,7 +35,7 @@ The `options` are:
 1. `env`: A dictionary of environment variables to set for the executable, with the possible keys `inherit` and `vars
 2. `workdir`: The `working directory for the executable.
 3. `watch`: Watch directories and carry out an action based on changes in these.
-4. `stdin`: Dictionary of data to pass in on standard in. 
+4. `stdin`: Dictionary of data to pass in on standard in, or the string 'close`. The dictionary should contain a key `type` (value `json` or `msgpack`) and a key `value` which is the data to JSON/msgpack encode. Optionally, `close` can be a key (value `true`) as well, causing stdin to be closed after the data is written.
 5. `stdout`: Action on signal on standard out, can be `close`, `log` or `drop`
 6. `stderr`: Action on signal on standard error, can be `close`, `log` or `drop`
 

--- a/website/crossbario/docs/How-Subscriptions-Work.md
+++ b/website/crossbario/docs/How-Subscriptions-Work.md
@@ -1,6 +1,6 @@
 With the Publish & Subscribe (PubSub) messaging pattern in WAMP, a WAMP client issues a subscription request to a router, in which it expresses interest in a topic. The router registers this. Whenever a publication to this topic comes in, an event is dispatched to all WAMP clients which are currently registered for the topic.
 
-For example, any WAMP client which has registered a subscription for the topic `com.myapp.topic1` receives an event whenever any other client publishes to the topic `com.myapp.topic1`. (The "any *other*" is because as a default, no event is dispatched to the publisher itself if it is subscribed to the topic. This behavior can be overriden.)
+For example, any WAMP client which has registered a subscription for the topic `com.myapp.topic1` receives an event whenever any other client publishes to the topic `com.myapp.topic1`. (The "any *other*" is because as a default, no event is dispatched to the publisher itself if it is subscribed to the topic. This behavior can be overriden by setting `exclude_me=False` in `PublishOptions` when calling `publish()`).
 
 The 'subscription', as the term is used here, exists within the router. A subscription is created when a client sends a subscription request for a topic where there are currently no other subscribers. It is deleted when the last subscriber cancels its subscriptions, or its session is disconnected.
 


### PR DESCRIPTION
Clarifies how to do use exclude_me and documents options to ``stdin`` for guest workers.