### PR TITLE
Fix bytes encode error in calling compute_wcs

### DIFF
--- a/website/crossbario/docs/WAMP-CRA-Authentication.md
+++ b/website/crossbario/docs/WAMP-CRA-Authentication.md
@@ -71,7 +71,6 @@ class MyFrontendComponent(wamp.ApplicationSession):
       else:
          raise Exception("don't know how to handle authmethod {}".format(challenge.method))
 
-   @inlineCallbacks
    def onJoin(self, details):
       print("ok, session joined!")
 ```

--- a/website/crossbario/docs/WAMP-CRA-Authentication.md
+++ b/website/crossbario/docs/WAMP-CRA-Authentication.md
@@ -66,7 +66,7 @@ class MyFrontendComponent(wamp.ApplicationSession):
    def onChallenge(self, challenge):
       if challenge.method == u"wampcra":
          signature = auth.compute_wcs(u"secret2".encode('utf8'),
-                                      challenge.extra['challenge'].encode('utf8'))
+                                      challenge.extra['challenge'])
          return signature.decode('ascii')
       else:
          raise Exception("don't know how to handle authmethod {}".format(challenge.method))


### PR DESCRIPTION
In the call to `compute_wcs` the challenge is already bytes. So trying to encode it as UTF-8 fails. You don't get to see the failure anywhere (I'm assuming it's being eaten / ignored at the end of a Twisted callback chain), unless you wrap the call to `compute_wcs` in a `try/except`, in which case you get an exception that can be printed: `Exception 'bytes' object has no attribute 'encode'`.

So there are really two problems here. One is that the doc example is wrong (fixed in this pr), the other is that the exception is being silently discarded: but it still causes my session app to disconnect with no explanation.

The state of the documentation around this super interesting and promising project is really abysmal, sorry to say :-( :-(