### PR TITLE
document options

### DIFF
--- a/website/crossbario/docs/Endpoints.md
+++ b/website/crossbario/docs/Endpoints.md
@@ -54,7 +54,7 @@ Option | Description
 **`interface`** | optional interface to listen on, e.g. `127.0.0.1` to only listen on IPv4 loopback or `::1` to only listen on IPv6 loopback.
 **`backlog`** | optional accept queue depth of listening endpoints (default: **50**)
 **`shared`** | flag which controls sharing the socket between multiple workers - this currently only works on Linux >= 3.9 (default: **false**)
-**`tls`** | optional endpoint TLS configuration
+**`tls`** | optional endpoint TLS configuration. If present, this is a dict containing keys: `key`: file path; `certificate`: file path; `dhparam`: (optional) file path; `ciphers`: (optional) list of strings. Relative paths are allowed, based from the directory the config file is in.
 
 #### TCP Connecting Endpoints
 
@@ -68,6 +68,18 @@ Here is an *Endpoint* that is connecting over TCP to `localhost` on port 8080:
 }
 ```
 
+Here is a listening *Endpoint* that uses TLS (note there's "interface" instead of "host"):
+
+```javascript
+"endpoint": {
+    "type": "tcp",
+    "interface": "127.0.0.1",
+    "port": 443,
+    "tls": {
+        "key": "server.key",
+        "certificate": "server.crt"
+    }
+```
 TCP connecting *Endpoints* can be configured using the following parameters:
 
 Option | Description

--- a/website/crossbario/docs/Native-Worker-Shared-Options.md
+++ b/website/crossbario/docs/Native-Worker-Shared-Options.md
@@ -9,7 +9,7 @@ option | description
 **`pythonpath`** | A list of paths to prepend to the Python seach path, e.g. `["..", "/home/joe/mystuff"]` (default: **[]**)
 **`cpu_affinity`** | The worker CPU affinity to set - a list of CPU IDs (integers), e.g. `[0, 1]` (default: **unset**) - currently only supported on Linux and Windows, [not on FreeBSD](https://github.com/giampaolo/psutil/issues/566)
 **`reactor`** | Choose the type of Twisted reactor, instead of the one chosen automatically. See below.
-**`env`** | Environment variables to pass to components within the worker.
+**`env`** | Environment variables to pass to components within the worker. This should be a `dict` with two keys: **inherit** which is a bool or a list of variables to inherit; and **vars** which is a `dict` of (additional) environment variables to set.
 
 Selecting a **Twisted reactor** is platform-based: `reactor` takes a dictionary as an argument, with the platform as the keys and a single reactor per platform as the value.
 


### PR DESCRIPTION
Adds documentation for a couple undocumented dicts: 'tls' in endpoints and 'env' in native worker options.